### PR TITLE
fix: ens not resolving

### DIFF
--- a/Creative/apps/creative-tv/src/providers/Web3.tsx
+++ b/Creative/apps/creative-tv/src/providers/Web3.tsx
@@ -1,4 +1,4 @@
-import { configureChains, createClient, WagmiConfig } from 'wagmi'
+import { configureChains, createClient, mainnet, WagmiConfig } from 'wagmi'
 import { publicProvider } from 'wagmi/providers/public'
 import { ConnectKitProvider, getDefaultClient } from 'connectkit'
 import { POLYGON_CHAINS, SITE_NAME, INFURA_API_KEY } from '../utils/config'
@@ -11,10 +11,10 @@ interface Props {
   children: ReactNode
 }
 
-const { provider, webSocketProvider, chains } = configureChains(POLYGON_CHAINS, [
-  infuraProvider({ apiKey: INFURA_API_KEY, priority: 0, stallTimeout: 1_000 }),
-  publicProvider({ priority: 2, stallTimeout: 1_000 }),
-])
+const { provider, webSocketProvider } = configureChains(
+  [...POLYGON_CHAINS, mainnet],
+  [infuraProvider({ apiKey: INFURA_API_KEY, priority: 0, stallTimeout: 1_000 }), publicProvider({ priority: 2, stallTimeout: 1_000 })]
+)
 
 const client = createClient(
   getDefaultClient({
@@ -22,7 +22,7 @@ const client = createClient(
     autoConnect: true,
     provider,
     webSocketProvider,
-    chains,
+    chains: POLYGON_CHAINS,
   })
 )
 

--- a/Creative/apps/creative-tv/src/providers/Web3.tsx
+++ b/Creative/apps/creative-tv/src/providers/Web3.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const { provider, webSocketProvider } = configureChains(
   [...POLYGON_CHAINS, mainnet],
-  [infuraProvider({ apiKey: INFURA_API_KEY, priority: 0, stallTimeout: 1_000 }), publicProvider({ priority: 2, stallTimeout: 1_000 })]
+  [infuraProvider({ apiKey: INFURA_API_KEY, priority: 0, stallTimeout: 1_000 }), publicProvider({ priority: 1, stallTimeout: 1_000 })]
 )
 
 const client = createClient(


### PR DESCRIPTION
Include mainnet chain in the provider configuration and only pass the polygon chains to the client configuration. That way the provider knows how to talk to mainnet, but we still limit login/sign-in to the polygon chains.

Now ENS names should resolve without error 👍 